### PR TITLE
Introduce new COUNT_DISTINCT_NULL function

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>org.sgodden</groupId>
 	<artifactId>sgo-query</artifactId>
 	<packaging>jar</packaging>
-	<version>1.3-SNAPSHOT</version>
+	<version>1.4-SNAPSHOT</version>
 	<name>sgo-query</name>
 	<url>http://www.sgodden.org</url>
 	<dependencies>

--- a/src/main/java/org/sgodden/query/AggregateFunction.java
+++ b/src/main/java/org/sgodden/query/AggregateFunction.java
@@ -68,6 +68,11 @@ public enum AggregateFunction {
 	 * Selects the count of distinct values
 	 */
 	COUNT_DISTINCT,
+
+	/**
+	 * Selects the count of distinct values with null counting as a single value
+	 */
+	COUNT_DISTINCT_NULL,
 	
 	/**
 	 * <p>Concatenates the column values using a delimiter set on the query service.</p>

--- a/src/main/java/org/sgodden/query/service/QueryStringBuilder.java
+++ b/src/main/java/org/sgodden/query/service/QueryStringBuilder.java
@@ -576,7 +576,8 @@ public class QueryStringBuilder {
                         ret.append("SUM(");
                     } else if (func == AggregateFunction.COUNT) {
                         ret.append("COUNT(");
-                    } else if (func == AggregateFunction.COUNT_DISTINCT) {
+                    } else if (func == AggregateFunction.COUNT_DISTINCT 
+                            || AggregateFunction.COUNT_DISTINCT_NULL.equals(func)) {
                         ret.append("COUNT(DISTINCT ");
                     } else if (func == AggregateFunction.GROUP_CONCAT) {
                         ret.append("GROUP_CONCAT(");
@@ -592,6 +593,15 @@ public class QueryStringBuilder {
 
                 if (func != null) {
                     ret.append(")");
+                    
+                    if (AggregateFunction.COUNT_DISTINCT_NULL.equals(func)) {
+                        ret.append(" + MAX(CASE WHEN ");
+
+                        ret.append(QueryUtil.getQualifiedAttributeIdentifier(col
+                                .getAttributePath()));
+                        
+                        ret.append(" IS NULL THEN 1 ELSE 0 END)");
+                    }
                 }
 
             }


### PR DESCRIPTION
Add COUNT_DISTINCT_NULL function; this extends the COUNT_DISTINCT function to support NULL as a distinct value; typically if you have a column containing values 1,2,2,1,NULL and use COUNT_DISTINCT the value will be 2. Using COUNT_DISTINCT_NULL the value will be 3.

The implementation behind this is to add 1 to the count if any of the column values are null:

SELECT COUNT(DISTINCT o.col) + MAX(CASE WHEN o.col IS NULL THEN 1 ELSE 0 END) ...

We cannot use COUNT(DISTINCT COALESCE(o.col, someRandomString)) because HQL doesn't support it (Query Syntax Exception at runtime) and choosing someRandomString that would never be used is practically impossible.
